### PR TITLE
Some more examples

### DIFF
--- a/examples/narrowing/isinstance_list.py
+++ b/examples/narrowing/isinstance_list.py
@@ -1,0 +1,20 @@
+"""The way mypy and pyright handle narrowing to a list is unsound.
+
+Mypy narrows to list[Any], pyright narrows to list[object], both of which allow
+appending arbitrary values. A sound solution could be to narrow to a type like
+`forall T. list[T]` (which cannot be expressed in Python). Such a type would not
+allow appending anything.
+"""
+
+from typing import Sequence
+
+
+def doit(lst: Sequence[object], x: int):
+    if isinstance(lst, list):
+        lst.append(x)
+
+
+def func(x: int) -> str:
+    lst: list[str] = []
+    doit(lst, x)
+    return lst[0]

--- a/examples/override/child_get.py
+++ b/examples/override/child_get.py
@@ -1,0 +1,29 @@
+"""Adding __get__ in a child class can lead to unsoundness, but type checkers do not flag it."""
+
+
+class Box:
+    def __init__(self, x: int):
+        self.x = x
+
+
+class Base:
+    def __init__(self, x: str):
+        self.x = x
+
+
+class Child(Base):
+    def __init__(self, x: str, y: int):
+        self.x = x
+        self.y = y
+
+    def __get__(self, instance: object, owner: type) -> Box:
+        return Box(self.y)
+
+
+class Holder:
+    attr: Base
+
+
+def func(x: int) -> str:
+    Holder.attr = Child("x", x)
+    return Holder.attr.x

--- a/examples/override/init.py
+++ b/examples/override/init.py
@@ -1,0 +1,19 @@
+"""Type checkers allow unsound overrides of `__init__`."""
+
+
+class Base:
+    def __init__(self, x: int) -> None:
+        self.x = str(x)
+
+
+class Child(Base):
+    def __init__(self, x: str) -> None:
+        self.x = x
+
+
+def doit(t: type[Base], x: int) -> str:
+    return t(x).x
+
+
+def func(x: int) -> str:
+    return doit(Child, x)

--- a/examples/stdlib/pow_any.py
+++ b/examples/stdlib/pow_any.py
@@ -1,0 +1,9 @@
+"""One of the overloads for `int.__pow__` is declared as returning Any. This can be exploited to
+produce unsoundness."""
+
+
+def func(x: int) -> str:
+    z = x
+    x = 1 + abs(x)
+    x **= -x
+    return str(x) if isinstance(x, int) else z


### PR DESCRIPTION
`pow_any.py` is by @oscarbenjamin in https://discuss.python.org/t/collecting-examples-of-unsoundness/97568/3 . `child_get.py` based on one of the issues listed by @mikeshardmind in https://discuss.python.org/t/collecting-examples-of-unsoundness/97568/5 .