### PR TITLE
TypeError due to unhashability when using `in` with some iterable types (eg: dict/set) an unhashable types (eg: list[int])

### DIFF
--- a/examples/stdlib/iterable_type_unhashable.py
+++ b/examples/stdlib/iterable_type_unhashable.py
@@ -1,0 +1,29 @@
+"""
+This example shows how functions, such as `in` may have different implementations
+for an abstract type. Some of these implementations may have additional requirements
+beyond what is specified for the function.
+
+In this example, an unhashable data type is used as the type for an iterable. Some
+types, like lists and tuples, will be able to use `in` since this is based on
+iteration through the object. Others, like a dict or set, will fail since they rely
+on the hashability of the input.
+
+In the example below, a list input will work, but a dictionary input will not:
+
+```py
+check_is_in([], [1, 2, 3])  # This returns False, and does not error
+check_is_in({}, [1, 2, 3])  # This throws a TypeError since [1, 2, 3] is not hashable.
+```
+"""
+
+from collections.abc import Iterable
+
+
+def check_is_in(input_iterable: Iterable[list[int]], value: list[int]) -> bool:
+    return value in input_iterable
+
+
+def func(x: int) -> int:
+    # No error results when [] is the iterable type, unlike a dict or set
+    # which will result in a TypeError
+    return x if not check_is_in([], [x]) else x + 1


### PR DESCRIPTION
This is an example where an Iterable type is made with an unhashable data type (in this case a `list[int]`). Depending on what Iterable object type is used, the `in` function may return a `TypeError` due to this unhashability.

While this is a pretty contrived example, this could occur in more natural code. I've seen this happen with a data class that was not hashable.

This works when the input is an empty set/dict or other iterable that has this issue. So even doing something like the following, will throw an error since I have not seen type checkers that can validate a type is unhashable until runtime.

```py
input_set: set[list[int]] = set()  # No error since creating an empty set is valid for set[list[int]]
check_is_in(input_set, [42])  # This throws TypeError
```

This comes from a larger example that I detailed here: https://www.lonfarr.com/posts/2025-05-18-iterable_membership_check/