### PR TITLE
add a couple descriptor-related examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ corresponding to subdirectories within the `examples/` directory:
 * `tuple`: related to special-cased tuple types
 * `runtime`: runtime manipulation of objects that the type system does not recognize
 * `generic`: use of generic classes and functions
+* `descriptors`: use of descriptors
 
 More categories can be added as needed.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repo sets a more concrete goal: write a function that can be used to fool
 a type checker into turning a value of one type into another. Concretely, we
 collect pieces of code with the following properties:
 
-* There is a `def convert(x: int) -> str:`
+* There is a `def func(x: int) -> str:`
 * At runtime, the function returns any integer argument unchanged
 * Type checkers accept the code without errors
 

--- a/examples/descriptors/subclass_adds_dunder_get.py
+++ b/examples/descriptors/subclass_adds_dunder_get.py
@@ -1,0 +1,12 @@
+class MyStr(str):
+    def __get__(self, instance: "C", owner: object) -> int:
+        return instance.val
+
+class C:
+    def __init__(self, val: int):
+        self.val = val
+
+    x: str = MyStr()
+
+def func(x: int) -> str:
+    return C(x).x

--- a/examples/descriptors/subclass_adds_dunder_get.py
+++ b/examples/descriptors/subclass_adds_dunder_get.py
@@ -2,11 +2,13 @@ class MyStr(str):
     def __get__(self, instance: "C", owner: object) -> int:
         return instance.val
 
+
 class C:
     def __init__(self, val: int):
         self.val = val
 
     x: str = MyStr()
+
 
 def func(x: int) -> str:
     return C(x).x

--- a/examples/narrowing/narrowing_descriptor_attribute.py
+++ b/examples/narrowing/narrowing_descriptor_attribute.py
@@ -1,0 +1,17 @@
+class Desc:
+    def __get__(self, instance: "C", owner: object) -> int | str:
+        return instance.val
+
+    def __set__(self, instance: "C", value: int | str) -> None:
+        pass
+
+class C:
+    def __init__(self, val: int):
+        self.val = val
+
+    x: Desc = Desc()
+
+def func(x: int) -> str:
+    c = C(x)
+    c.x = "foo"
+    return c.x

--- a/examples/narrowing/narrowing_descriptor_attribute.py
+++ b/examples/narrowing/narrowing_descriptor_attribute.py
@@ -5,11 +5,13 @@ class Desc:
     def __set__(self, instance: "C", value: int | str) -> None:
         pass
 
+
 class C:
     def __init__(self, val: int):
         self.val = val
 
     x: Desc = Desc()
+
 
 def func(x: int) -> str:
     c = C(x)


### PR DESCRIPTION
One of the two added examples clearly fits into the "narrowing" category (it uses a descriptor, but it's about narrowing behavior.) The other one didn't seem to clearly fit in any existing category -- the unsoundness is fundamentally about the type system's treatment of descriptors themselves. I created a new "descriptors" category for this one.

I also adjusted the README to use the function name `func` that is actually required in examples.
