### PR TITLE
Add example of how modifying __closure__ is unsound

### DIFF
--- a/examples/runtime/closure.py
+++ b/examples/runtime/closure.py
@@ -1,0 +1,34 @@
+"""
+If a variable is captured with closure, it is stored in the dunder
+__closure__ cell. It is possible to modify the cell contents manually,
+thus modifying the underlying value.
+
+This is not typically feasible without knowing the code, so this is
+relatively limited in how it could be used in the real world.
+"""
+
+from types import CellType
+from typing import Callable
+
+
+class ClosureTestClass:
+    def __init__(self, x: int) -> None:
+        str_x: str = str(x)
+
+        def get_str_x() -> str:
+            nonlocal str_x  # Not strictly needed but helps with clarity
+            return str_x
+
+        self.get_str_x: Callable[[], str] = get_str_x
+
+
+def func(x: int) -> str:
+    closure_test_class: ClosureTestClass = ClosureTestClass(x)
+
+    # Since this can be None or have no items, save off and run
+    # within an if statement
+    closure: tuple[CellType, ...] | None = closure_test_class.get_str_x.__closure__
+    if closure:
+        closure[0].cell_contents = x
+
+    return closure_test_class.get_str_x()

--- a/examples/runtime/closure.py
+++ b/examples/runtime/closure.py
@@ -17,7 +17,7 @@ class ClosureTestClass:
         def get_str_x() -> str:
             return str_x
 
-        self.get_str_x: Callable[[], str] = get_str_x
+        self.get_str_x = get_str_x
 
 
 def func(x: int) -> str:

--- a/examples/runtime/closure.py
+++ b/examples/runtime/closure.py
@@ -7,27 +7,25 @@ This is not typically feasible without knowing the code, so this is
 relatively limited in how it could be used in the real world.
 """
 
-from types import CellType
 from typing import Callable
 
 
 class ClosureTestClass:
     def __init__(self, x: int) -> None:
-        str_x: str = str(x)
+        str_x = str(x)
 
         def get_str_x() -> str:
-            nonlocal str_x  # Not strictly needed but helps with clarity
             return str_x
 
         self.get_str_x: Callable[[], str] = get_str_x
 
 
 def func(x: int) -> str:
-    closure_test_class: ClosureTestClass = ClosureTestClass(x)
+    closure_test_class = ClosureTestClass(x)
 
     # Since this can be None or have no items, save off and run
     # within an if statement
-    closure: tuple[CellType, ...] | None = closure_test_class.get_str_x.__closure__
+    closure = closure_test_class.get_str_x.__closure__
     if closure:
         closure[0].cell_contents = x
 

--- a/examples/runtime/dunder_variables.py
+++ b/examples/runtime/dunder_variables.py
@@ -15,14 +15,14 @@ the non-mangled variable with a new, different value type.
 
 class HiddenDunderVariables:
     def __init__(self, x: int) -> None:
-        self.__str_x: str = str(x)
-        self._HiddenDunderVariables__str_x: int = x
+        self.__str_x = str(x)
+        self._HiddenDunderVariables__str_x = x
 
     def get_str_x(self) -> str:
         return self.__str_x
 
 
 def func(x: int) -> str:
-    hidden_dunder_variables: HiddenDunderVariables = HiddenDunderVariables(x)
+    hidden_dunder_variables = HiddenDunderVariables(x)
 
     return hidden_dunder_variables.get_str_x()

--- a/examples/stdlib/setattr.py
+++ b/examples/stdlib/setattr.py
@@ -7,14 +7,14 @@ variable and overwrite with a different type.
 
 class ToString:
     def __init__(self, x: int) -> None:
-        self.str_x: str = str(x)
+        self.str_x = str(x)
 
     def get_str_x(self) -> str:
         return self.str_x
 
 
 def func(x: int) -> str:
-    to_string: ToString = ToString(x)
+    to_string = ToString(x)
     setattr(to_string, "str_x", x)
 
     return to_string.get_str_x()


### PR DESCRIPTION
This requires manually modifying values based on knowledge of the code, and where captured variables are stored, so it is not very practical or likely used in any real world scenarios. I 100% will admit that doing anything like this is A Really Bad Idea™ so feel free to reject if this is too esoteric.

With that being said, `__closure__` can contain variables that are referenced in a function, in this case via nonlocal that would have gone out of scope when `__init__` exits. You can then modify these values behind the back of the type checker. But if you are modifying `__closure__`, you are likely doing something you shouldn't be doing.