### PR TITLE
Add context manager examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ corresponding to subdirectories within the `examples/` directory:
 * `runtime`: runtime manipulation of objects that the type system does not recognize
 * `generic`: use of generic classes and functions
 * `descriptors`: use of descriptors
+* `ctx-managers`: related to context managers
 
 More categories can be added as needed.
 

--- a/examples/ctx-managers/error_while_binding.py
+++ b/examples/ctx-managers/error_while_binding.py
@@ -1,0 +1,20 @@
+from typing import Literal
+
+
+class CoolCtxManager:
+    def __enter__(self) -> list[str]:
+        return ["b", "a", "n", "a", "n", "a"]
+
+    def __exit__(self, *args: object) -> Literal[True]:
+        return True
+
+
+def func(x: int) -> str:
+    a: int | str = x
+
+    # binding (assignment into targets after `as`) is considered part of the
+    # context manager body, so exceptions during the binding can be silenced
+    with CoolCtxManager() as [a, _b]:
+        pass
+
+    return a

--- a/examples/ctx-managers/exception_swallowing.py
+++ b/examples/ctx-managers/exception_swallowing.py
@@ -1,0 +1,18 @@
+import contextlib
+from collections.abc import Iterator
+
+
+@contextlib.contextmanager
+def yolo() -> Iterator[None]:
+    try:
+        yield
+    except Exception:
+        pass
+
+
+def func(x: int) -> str:
+    y: int | str = x
+    with yolo():
+        print(1 / 0)
+        y = "hello"
+    return y


### PR DESCRIPTION
The ability of context managers to swallow exceptions makes control flow analysis tricky.