### PR TITLE
simplified example for abstract set |=

### DIFF
--- a/examples/stdlib/mutable_inplace.py
+++ b/examples/stdlib/mutable_inplace.py
@@ -2,7 +2,9 @@
 This example is concerned with the difficulty of typing binary operators.
 
 When augmented assignment is performed on a mutable collection, the collection
-is mutated in-place. In other words, `x += y` and `x = x + y` are not the same:
+is mutated in-place. In other words, `x += y` and `x = x + y` are not necessarily the same.
+It depends on the specific implementation of the runtime type (whether it implements
+__iadd__ or not). Therefore it is not safe to make assumptions on the abstract level:
 
 ```py
 xs = [1, 2, 3]

--- a/examples/stdlib/mutable_inplace.py
+++ b/examples/stdlib/mutable_inplace.py
@@ -21,14 +21,9 @@ assert xs == [1, 2, 3]
 from collections.abc import Set as AbstractSet
 
 
-def _enhance_fruits(
-    fruits: AbstractSet[str | int], fruit: int | str
-) -> AbstractSet[str | int]:
-    fruits |= {fruit}
-    return fruits
-
-
 def func(x: int) -> str:
-    fruits: set[str] = {"apple", "banana"}
-    _ = _enhance_fruits(fruits, x)
-    return next(f for f in fruits if f not in {"apple", "banana"})
+    # should not be mutable and should only contain ints
+    result: AbstractSet[str] = set()
+    other: AbstractSet[object] = result
+    other |= {x}
+    return next(iter(result))


### PR DESCRIPTION
I was going to open a PR to add this as an example in `runtime`. But grepping for `|=` revealed that a similar example already existed. I do believe mine is simpler, i.e. it showcases the issue more directly. So I thought I'd open a PR anyway to see what you think.

I also expanded slightly on the description above the snippet.