### PR TITLE
add hybrid-wrapper/descriptor example

### DIFF
--- a/examples/descriptors/hybrid_descriptor_or_wrapper.py
+++ b/examples/descriptors/hybrid_descriptor_or_wrapper.py
@@ -2,29 +2,32 @@ from typing import Callable, Concatenate
 
 
 class WrapperOrDesc[**_P, _T]:
-    def __init__(self, func:Callable[_P, _T], i:object | None = None):
+    def __init__(self, func: Callable[_P, _T], i: object | None = None):
         self.func = func
         self.i = i
-    
-    def __call__(self, *args:_P.args, **kwds:_P.kwargs) -> _T:
+
+    def __call__(self, *args: _P.args, **kwds: _P.kwargs) -> _T:
         if self.i:
             return self.func(self.i, *args, **kwds)
         return self.func(*args, **kwds)
-    
-    def __get__[_I](self: "WrapperOrDesc[Concatenate[_I, _P], _T]", instance:_I, owner:type[_T]) -> "WrapperOrDesc[_P, _T]":
+
+    def __get__[_I](
+        self: "WrapperOrDesc[Concatenate[_I, _P], _T]", instance: _I, owner: type[_T]
+    ) -> "WrapperOrDesc[_P, _T]":
         return WrapperOrDesc(self.func, instance)
 
 
 class Class(object):
     @WrapperOrDesc
-    def method(self, i:int) -> int:
+    def method(self, i: int) -> int:
         return i
 
+
 @WrapperOrDesc
-def func(i:int) -> int:
+def func(i: int) -> int:
     return i
+
 
 func(1)
 c = Class()
 c.method(1)
-


### PR DESCRIPTION
Decided to add a thing to your example of broken python scripts with one that attempts to be a hybrid of either a member-descriptor or a function wrapper. This has been a problem with async_lru from the day I wanted to add better typehinting to things such as lru_cache. The bug Revolves around ParamSpec Not removing Self when wrapping a function around a hybrid descriptor/wrapper.
