### PR TITLE
Add example with `match` and a mapping pattern

### DIFF
--- a/examples/narrowing/match_mapping.py
+++ b/examples/narrowing/match_mapping.py
@@ -1,0 +1,35 @@
+from collections.abc import Iterator, Mapping
+
+
+class Foo:
+    pass
+
+
+class BananaSecret(Foo, Mapping[str, int]):
+    def __init__(self, secret: int) -> None:
+        self._secret = secret
+
+    def __iter__(self) -> Iterator[str]:
+        yield "banana"
+
+    def __len__(self) -> int:
+        return 1
+
+    def __getitem__(self, key: str) -> int:
+        if key != "banana":
+            raise KeyError(key)
+        return self._secret
+
+
+def helper(mystery_object: Foo | dict[str, str]) -> str:
+    match mystery_object:
+        case {"banana": secret}:
+            # Logical fallacy here: mapping pattern matches => mystery_object cannot be Foo
+            return secret
+
+        case _:
+            return "hello"
+
+
+def func(x: int) -> str:
+    return helper(BananaSecret(x))


### PR DESCRIPTION
I believe a similar issue will occur with sequence patterns, but this should be enough for demonstration.