### PR TITLE
Add example of assigning a protocol class to `type[_]`

### DIFF
--- a/nonexamples/protocol_constructor.py
+++ b/nonexamples/protocol_constructor.py
@@ -1,0 +1,29 @@
+"""
+Passing a protocol to type[Protocol] is banned, but not through a generic function.
+
+Works with pyright but not mypy.
+"""
+
+from typing import Literal, Protocol
+
+
+class Fooable(Protocol):
+    def foo(self) -> Literal["banana"]: ...
+
+
+class Banana:
+    def foo(self) -> Literal["banana"]:
+        return "banana"
+
+
+def _impl[F: Fooable](t: type[F], inst: F, wrong: int) -> str:
+    banana = t.foo(inst)
+    return banana or wrong  # this type checks because `banana` is supposed
+    # to always be truthy
+
+
+def func(x: int) -> str:
+    return _impl(Fooable, Banana(), x)
+
+
+ACCEPTED_BY = {"mypy": False, "pyright": True}


### PR DESCRIPTION
The typing spec prohibits passing a protocol class `SomeProtocol` where a `type[SomeProtocol]` is expected: https://typing.python.org/en/latest/spec/protocol.html#type-and-class-objects-vs-protocols

Pyright does implement this (in https://github.com/microsoft/pyright/issues/2731) but not when it's done through a type variable.