### PR TITLE
Add example of calling a method on the wrong class

### DIFF
--- a/examples/method_mixup.py
+++ b/examples/method_mixup.py
@@ -1,0 +1,28 @@
+class Fooable:
+    def foo(self) -> str:
+        return ""
+
+
+class Apple(Fooable):
+    def __init__(self, x: object) -> None:
+        self._x = x
+
+    def foo(self) -> str:
+        return str(self._x)
+
+
+class Banana(Fooable):
+    def __init__(self, x: str) -> None:
+        self._x = x
+
+    def foo(self) -> str:
+        return self._x
+
+
+def _impl(first: type[Fooable], second: Fooable) -> str:
+    return first.foo(second)
+
+
+def func(x: int) -> str:
+    # This is going to call `Banana.foo` with an instance of `Apple`
+    return _impl(Banana, Apple(x))


### PR DESCRIPTION
I placed it in the `examples/` category directly because I can't think of a neat category for this error. 

A subclass _technically_ always violates LSP if it overrides a method, since `self` in the child method has a new restriction on `self` that the parent didn't have.

This also works when `Fooable` is a protocol.