### PR TITLE
Add example of unsound `__bool__` assumption in pyright

### DIFF
--- a/nonexamples/bool_override.py
+++ b/nonexamples/bool_override.py
@@ -1,0 +1,35 @@
+from typing import Literal
+
+
+class Foo:
+    def __init__(self, value: int) -> None:
+        self.value = value
+
+
+class FalseyFoo(Foo):
+    def __bool__(self) -> Literal[False]:
+        return False
+
+
+class Bar:
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+    def __bool__(self) -> Literal[False]:
+        return False
+
+
+def helper(x: Foo | Bar) -> str:
+    if x:
+        # x narrowed to `Foo` here
+        return str(x.value)
+    else:
+        # x narrowed to `Bar` here
+        return x.value
+
+
+def func(x: int) -> str:
+    return helper(FalseyFoo(x))
+
+
+ACCEPTED_BY = {"mypy": False, "pyright": True}


### PR DESCRIPTION
`mypy` considers an instance of a class as always truthy if either:

- it is `@final` and doesn't override `__bool__`
- defines `__bool__` as always returning `Literal[True]`

`pyright` on the other hand considers that if a class doesn't override `object.__bool__`, its instances are always truthy. Even if that class is an `ABC` (but not if it's a `Protocol`)