### PR TITLE
Add an example using a nonlocal assignment

### DIFF
--- a/examples/narrowing/nonlocal_assignment.py
+++ b/examples/narrowing/nonlocal_assignment.py
@@ -1,8 +1,10 @@
 def func(x: int) -> str:
     union: int | str
+
     def helper():
         nonlocal union
         union = x
+
     union = "hello"
     helper()
     return union

--- a/examples/narrowing/nonlocal_assignment.py
+++ b/examples/narrowing/nonlocal_assignment.py
@@ -1,0 +1,8 @@
+def func(x: int) -> str:
+    union: int | str
+    def helper():
+        nonlocal union
+        union = x
+    union = "hello"
+    helper()
+    return union


### PR DESCRIPTION
I'm not sure that `union = "hello"` is really "narrowing" per se, but it seemed like the closest fit among the existing subdirs. Let me know if there's a better name/place for this example?