### PR TITLE
Add old-style `TypeVar` variance example

### DIFF
--- a/examples/generic/old_style_typevar_variance.py
+++ b/examples/generic/old_style_typevar_variance.py
@@ -1,0 +1,26 @@
+"""Variance in old-style `TypeVar`s is not thoroughly checked."""
+
+from typing import Generic, TypeVar
+
+T_co = TypeVar("T_co", covariant=True)
+
+
+class Foo(Generic[T_co]):
+    def __init__(self) -> None:
+        self._things: list[T_co] = []
+
+    def add_many(self, values: list[T_co]) -> None:
+        self._things.extend(values)
+
+    def pop(self) -> T_co:
+        return self._things.pop()
+
+
+def _helper(foo: Foo[int | str], x: int) -> None:
+    foo.add_many([x])
+
+
+def func(x: int) -> str:
+    foo: Foo[str] = Foo()
+    _helper(foo, x)
+    return foo.pop()


### PR DESCRIPTION
For some reason, old-style `TypeVar`s are not checked for variance thoroughly. Checking is done for simple cases when you just do `self.public: T_co = something` or accept a plain `T_co` as a method parameter, but not if it's part of a more complex type.

Despite a new style of type variables coming in 3.12, this is still relevant:
- if you want to use a new feature added to TypeVars (e.g. defaults, added in 3.13), you have to use `typing_extensions.TypeVar`, which suffer from the same problem
- 3.10 and 3.11 are still supported, so if your library wants to support them, you can't use new style type variables for the next 1.5 years

None of mypy, pyright, ty, pyrefly see a problem with the added snippet.